### PR TITLE
Fix Final Steps link

### DIFF
--- a/windows/git_bash.md
+++ b/windows/git_bash.md
@@ -99,4 +99,4 @@ When you installed PostgreSQL, the installer also installed some extra tools. On
 
 ### <a id="final-steps">Final Steps</a>
 
-When you are finished installing the Heroku CLI and PostgreSQL, please move here to complete your [Final Steps](./final_steps.md)
+When you are finished installing the Heroku CLI and PostgreSQL, please move here to complete your [Final Steps](../final_steps.md)


### PR DESCRIPTION
`./final_steps.md` looked for the file in the current `windows` directory. It needed an extra period to move back to the `master` directory.